### PR TITLE
Fix problems with removing items from the queue while the tracklist editor is open

### DIFF
--- a/src/renderer/src/components/TracklistTable.jsx
+++ b/src/renderer/src/components/TracklistTable.jsx
@@ -12,7 +12,7 @@ export default function TracklistTable({ tracklist }) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {tracklist.map(t => (
+          {tracklist?.map(t => (
             <TableRow key={t.timestamp}>
               <TableCell>{t.timestamp}</TableCell>
               <TableCell>{t.artist}</TableCell>

--- a/src/renderer/src/routes/QueueDetails.jsx
+++ b/src/renderer/src/routes/QueueDetails.jsx
@@ -1,5 +1,5 @@
 import { Button, Stack, TextField, Typography } from '@mui/material';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import useStore from '../components/Store';
 import TracklistTable from '../components/TracklistTable';
@@ -13,6 +13,12 @@ export function Component() {
   const [editing, setEditing] = useState(!track?.tracklist);
   const [input, setInput] = useState(track?.rawTracklist);
   const [hidden, setHidden] = useState(!track?.tracklistManuallyEdited);
+
+  useEffect(() => {
+    setEditing(!track?.tracklist);
+    setInput(track?.rawTracklist);
+    setHidden(!track?.tracklistManuallyEdited);
+  }, [track]);
 
   const save = useCallback(() => {
     const tracklist = parseTracklist(input);


### PR DESCRIPTION
Fixes #4.
Better solution would be using unique IDs for the route param instead, but I'll probably implement that later if/when I work on reordering.