### PR TITLE
Fix update check status message

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -107,6 +107,10 @@ autoUpdater.on('update-available', info => {
   mainWindow?.webContents.send('updates:update-available', info);
 });
 
+autoUpdater.on('update-not-available', info => {
+  mainWindow?.webContents.send('updates:update-not-available', info);
+});
+
 autoUpdater.on('download-progress', progress => {
   mainWindow?.webContents.send('updates:download-progress', progress);
 });

--- a/src/renderer/src/components/Settings.jsx
+++ b/src/renderer/src/components/Settings.jsx
@@ -26,8 +26,28 @@ export default function Settings() {
 
   const checkForUpdates = useCallback(async () => {
     setUpdateCheckStatus('Checking for updates...');
-    const hasUpdate = await window.api.updates.checkForUpdates();
-    setUpdateCheckStatus(hasUpdate ? 'There is a new update!' : 'You are already up to date');
+    const result = await window.api.updates.checkForUpdates();
+    if (!result) setUpdateCheckStatus("Couldn't check for updates");
+  }, []);
+
+  useEffect(() => {
+    const ipcRenderer = window.electron?.ipcRenderer;
+    if (!ipcRenderer) return;
+
+    const onUpdateAvailable = () => {
+      setUpdateCheckStatus('There is a new update!');
+    };
+    ipcRenderer.on('updates:update-available', onUpdateAvailable);
+
+    const onUpdateNotAvailable = () => {
+      setUpdateCheckStatus('You are already up to date');
+    };
+    ipcRenderer.on('updates:update-not-available', onUpdateNotAvailable);
+
+    return () => {
+      ipcRenderer.removeListener('updates:update-available', onUpdateAvailable);
+      ipcRenderer.removeListener('updates:update-not-available', onUpdateNotAvailable);
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Incorrectly assumed the returned value would be `null` if there is no update. `null` actually means that the updater doesn't work (like in the dev environment)