### PR TITLE
Fallback to 0 offset if getting the duration fails

### DIFF
--- a/src/renderer/src/utils/parseAds.js
+++ b/src/renderer/src/utils/parseAds.js
@@ -31,7 +31,7 @@ export default async function parseAds(track) {
     // Blocking the ads would've been so much simpler fr...
     const adRes = await fetch(res.url, { headers: { range: `bytes=0-${startOfContent}` } });
     const preRollAds = await adRes.blob();
-    const tracklistOffset = await getDuration(preRollAds);
+    const tracklistOffset = await getDuration(preRollAds).catch(() => 0);
     track.tracklistOffset = tracklistOffset;
     track._debug.tracklistOffset = tracklistOffset;
   }


### PR DESCRIPTION
I encountered a weird case where the value I've labeled `startOfContent` was one less than `startOfAudio`. This was causing an error when trying to find out the duration between the two as fetching the bytes from 0 to `startOfContent` would have no valid audio. I've added a catch that defaults to 0 if an error like this occurs. There should be no impact if there is an actual offset to find.