### PR TITLE
Fix ad parsing

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -66,7 +66,7 @@ function createWindow() {
 
   // Expose some headers that normally aren't accessible with fetch
   mainWindow.webContents.session.webRequest.onHeadersReceived(
-    { urls: ['https://dcs.megaphone.fm/*'] },
+    { urls: ['https://*.megaphone.fm/*'] },
     (details, callback) => {
       callback({
         responseHeaders: {


### PR DESCRIPTION
1. The subdomain had changed so the headers weren't exposed
2. While testing I got my first double pre-roll and realized I had interpreted the payload wrong