### PR TITLE
Updater restart now button

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -129,6 +129,10 @@ ipcMain.on('updates:download-update', () => {
   autoUpdater.downloadUpdate();
 });
 
+ipcMain.on('updates:restart-and-update', () => {
+  autoUpdater.quitAndInstall();
+});
+
 ipcMain.handle('updates:check-for-updates', async () => {
   const result = await autoUpdater.checkForUpdates();
   return !!result;

--- a/src/preload/index.mjs
+++ b/src/preload/index.mjs
@@ -9,6 +9,7 @@ const api = {
   updates: {
     checkForUpdates: () => ipcRenderer.invoke('updates:check-for-updates'),
     downloadUpdate: () => ipcRenderer.send('updates:download-update'),
+    restartAndUpdate: () => ipcRenderer.send('updates:restart-and-update'),
     getAllowPrerelease: () => ipcRenderer.invoke('updates:get-allow-prerelease'),
     setAllowPrerelease: value => ipcRenderer.invoke('updates:set-allow-prerelease', value),
   },

--- a/src/renderer/src/components/UpdateBar.jsx
+++ b/src/renderer/src/components/UpdateBar.jsx
@@ -44,7 +44,7 @@ export default function UpdateBar() {
     };
   }, []);
 
-  const update = useCallback(() => {
+  const downloadUpdate = useCallback(() => {
     window.api.updates.downloadUpdate();
     setState(s => ({ ...s, status: 1 }));
   }, []);
@@ -64,7 +64,7 @@ export default function UpdateBar() {
                 What&apos;s new
               </ActionButton>
             ) : undefined}
-            {state.status === 0 ? <ActionButton onClick={update}>Update</ActionButton> : undefined}
+            {state.status === 0 ? <ActionButton onClick={downloadUpdate}>Download</ActionButton> : undefined}
             {state.status === 2 ? <ActionButton onClick={restartAndUpdate}>Restart now</ActionButton> : undefined}
             {state.status !== 1 ? (
               <IconButton

--- a/src/renderer/src/components/UpdateBar.jsx
+++ b/src/renderer/src/components/UpdateBar.jsx
@@ -49,6 +49,10 @@ export default function UpdateBar() {
     setState(s => ({ ...s, status: 1 }));
   }, []);
 
+  const restartAndUpdate = useCallback(() => {
+    window.api.updates.restartAndUpdate();
+  }, []);
+
   return (
     <Collapse in={state.open}>
       <Alert
@@ -61,6 +65,7 @@ export default function UpdateBar() {
               </ActionButton>
             ) : undefined}
             {state.status === 0 ? <ActionButton onClick={update}>Update</ActionButton> : undefined}
+            {state.status === 2 ? <ActionButton onClick={restartAndUpdate}>Restart now</ActionButton> : undefined}
             {state.status !== 1 ? (
               <IconButton
                 color="inherit"


### PR DESCRIPTION
Allows you to restart to install the update right away if you want to instead of having to close the app and wait for the silent updater to finish without progress indicators.