### PR TITLE
Deal with extra lines in RSS feeds

### DIFF
--- a/src/renderer/src/utils/parseTracklist.js
+++ b/src/renderer/src/utils/parseTracklist.js
@@ -1,5 +1,5 @@
 import { parseTimestamp } from './timestamp';
-const re = /(?:(?<special>.+):\n)?(?:\d+\. (?<l_track>.+?))?\[?(?<timestamp>\d+:\d+(?::\d+)?)\]?(?<r_track>.+)?/g;
+const re = /(?:(?<special>.+):\n+)?(?:\d+\. (?<l_track>.+?))?\[?(?<timestamp>\d+:\d+(?::\d+)?)\]?(?<r_track>.+)?/g;
 
 export default function parseTracklist(tracklist) {
   const parsed = [];

--- a/src/renderer/src/utils/processMetadata.js
+++ b/src/renderer/src/utils/processMetadata.js
@@ -43,7 +43,7 @@ export const processRss = item => {
     pictureUrl: item.itunes.image,
     thumbnailUrl: thumbnailUrl?.toString(),
     audioUrl: item.enclosure.url,
-    rawTracklist: item.contentSnippet,
+    rawTracklist: item['content:encodedSnippet'] ?? item.contentSnippet,
     duration: item.itunes.duration,
   };
 };


### PR DESCRIPTION
Ever since MSS 800 pt. 3 (5 May 2025) and COTW 555 (27 April 2025) the RSS description where the tracklist is located has had double line breaks.

This didn't really matter except for MSS tracklists where the exclusive and spotlight labels weren't attached to their tracks.

For example, MSS832 looks like this
```
Follow Monstercat Silk on all platforms - ⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠https://monster.cat/silk⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠

Follow our playlists: ⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠https://ffm.bio/monstercat⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠



Tracklist

1. MXV - Can You (ft. Courtney Storm) [Monstercat Silk] [00:35]



Silk Exclusive:

2. Approaching Black - Amber Glow [Monstercat Silk] [05:23]

3. Modd & Lisandro - Balloon [Monstercat Silk] [08:29]

4. ORACLE - Reflections [Monstercat Silk] [13:17]
```
instead of
```
Follow Monstercat Silk on all platforms - ⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠https://monster.cat/silk⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠
Follow our playlists: ⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠https://ffm.bio/monstercat⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠⁠

Tracklist
1. MXV - Can You (ft. Courtney Storm) [Monstercat Silk] [00:35]

Silk Exclusive:
2. Approaching Black - Amber Glow [Monstercat Silk] [05:23]

3. Modd & Lisandro - Balloon [Monstercat Silk] [08:29]
4. ORACLE - Reflections [Monstercat Silk] [13:17]
```

Dealing with this by making the regex accept multiple new lines between a "special" label and the track and switching to the HTML encoded content (`content:encodedSnippet`) which is clean